### PR TITLE
print error, don't re-try failed create table

### DIFF
--- a/python/createSchema.py
+++ b/python/createSchema.py
@@ -1,8 +1,6 @@
 import pyodbc
 import os
 
-
-
 def connect_to_iris():
     connection = get_connection_config()
     
@@ -52,7 +50,7 @@ def create_employee(connection):
         cursor.execute(create_employee)
     except Exception as e:
         delete_old_table(cursor, "Demo.Employee")
-        cursor.execute(create_employee)
+        print(e)
 
     connection.commit()
     print("created table successfully")


### PR DESCRIPTION
on exception, don't execute again the create table command that just failed in the try, print error instead